### PR TITLE
[PRI 279] Switch to TSI indexing

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,36 +1,37 @@
 ---
 driver:
-  name: vagrant
+  name: docker
 
 provisioner:
   name: ansible_playbook
   hosts: test-kitchen
-  require_pip: true
-  require_ansible_repo: false
-  ansible_version:  2.3.2.0
-  ansible_verbose:  false
-  ansible_verbosity: 2
-  ansible_diff: true
+  require_chef_for_busser: false
+  require_ansible_omnibus: false
+  ansible_version: 2.7.10-1ppa~trusty
+  ansible_verbose: false
+  ansible_verbosity: 3
   ansible_extra_flags: <%= ENV['ANSIBLE_EXTRA_FLAGS'] %>
   ignore_paths_from_root:
     - .kitchen
 
 platforms:
   - name: ubuntu-14.04
-    driver:
-      box: ubuntu/trusty64
-  - name: ubuntu-16.04
-    driver:
-      box: ubuntu/xenial64
-  - name: centos-7.2
-    driver:
-      box: bento/centos-7.2
+    driver_config:
+      image: ubuntu:14.04
+      platform: ubuntu
+      provision_command:
+        - apt-get install -y apt-transport-https
+
+verifier:
+  name: serverspec
+  default_pattern: true
+  sudo_path: true
 
 suites:
   - name: default
     driver:
       network:
-        - ["private_network", { ip: "172.29.129.176" }]
+        - ["private_network", { ip: "172.16.129.171" }]
 
 transport:
-  max_ssh_sessions: 4
+  forward_agent: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ influxdb_meta_logging_enabled: true
 influxdb_data_dir: "{{ influxdb_home_dir }}/data"
 influxdb_data_wal_dir: "{{ influxdb_home_dir }}/wal"
 influxdb_data_trace_logging_enabled: false
-# influxdb_data_query_log_enabled: true
+influxdb_data_query_log_enabled: false
 # influxdb_data_cache_max_memory_size: 1048576000
 # influxdb_data_cache_snapshot_memory_size: 26214400
 # influxdb_data_cache_snapshot_write_cold_duration: "1h"
@@ -42,6 +42,8 @@ influxdb_data_trace_logging_enabled: false
 #
 # influxdb_data_max_series_per_database: 1000000
 # influxdb_data_max_values_per_tag: 100000
+influxdb_index_version: "tsi1"
+influxdb_data_max_index_log_file_size: "2m"
 
 ### [coordinator]
 influxdb_coordinator_write_timeout: "10s"
@@ -76,7 +78,7 @@ influxdb_admin_https_certificate: "/etc/ssl/influxdb.pem"
 influxdb_http_enabled: true
 influxdb_http_bind_address: ":8086"
 influxdb_http_auth_enabled: false
-influxdb_http_log_enabled: true
+influxdb_http_log_enabled: false
 influxdb_http_write_tracing: false
 influxdb_http_pprof_enabled: false
 influxdb_http_https_enabled: false

--- a/templates/influxdb.conf.j2
+++ b/templates/influxdb.conf.j2
@@ -60,6 +60,8 @@ hostname = "{{ influxdb_hostname }}"
   # log any sensitive data contained within a query.
   query-log-enabled = {{ influxdb_data_query_log_enabled|default(false)|bool|lower }}
 
+  index-version = "{{ influxdb_index_version }}"
+
   # Settings for the TSM engine
 
   # CacheMaxMemorySize is the maximum size a shard's cache can
@@ -92,6 +94,8 @@ hostname = "{{ influxdb_hostname }}"
   compact-full-write-cold-duration = {{ influxdb_data_compact_full_write_cold_duration }}
 {% endif %}
 
+  # In-memory (`inmem`) Index Settings
+
   # The maximum series allowed per database before writes are dropped.  This limit can prevent
   # high cardinality issues at the database level.  This limit can be disabled by setting it to
   # 0.
@@ -107,6 +111,11 @@ hostname = "{{ influxdb_hostname }}"
 {% if influxdb_data_max_values_per_tag|default(false) %}
   max-values-per-tag = {{ influxdb_data_max_values_per_tag }}
 {% endif %}
+
+  # Disk (`tsi1`) Index Settings
+
+  max-index-log-file-size = "{{ influxdb_data_max_index_log_file_size }}"
+  series-id-set-cache-size = 100
 
 ###
 ### [coordinator]


### PR DESCRIPTION
This change switches to TSI (`tsi1`) indexing model for InfluxDB to avoid OOM exceptions that were occurring.
Also disabled http logging for InfluxDB